### PR TITLE
Add --api-key option for uploading recordings

### DIFF
--- a/src/bin.js
+++ b/src/bin.js
@@ -29,6 +29,10 @@ program
     "--server <address>",
     "Alternate server to upload recordings to."
   )
+  .option(
+    "--api-key <key>",
+    "Authentication API Key"
+  )
   .action(commandUploadRecording);
 
 program
@@ -41,6 +45,10 @@ program
   .option(
     "--server <address>",
     "Alternate server to upload recordings to."
+  )
+  .option(
+    "--api-key <key>",
+    "Authentication API Key"
   )
   .action(commandUploadAllRecordings);
 

--- a/src/client.js
+++ b/src/client.js
@@ -15,16 +15,32 @@ class ProtocolClient {
     this.socket.on("open", callbacks.onOpen);
     this.socket.on("close", callbacks.onClose);
     this.socket.on("error", callbacks.onError);
-    this.socket.on("message", message => this.onMessage(message));
+    this.socket.on("message", (message) => this.onMessage(message));
   }
 
   close() {
     this.socket.close();
   }
 
+  async setAccessToken(accessToken) {
+    accessToken = accessToken || process.env.RECORD_REPLAY_API_KEY;
+
+    if (!accessToken) {
+      throw new Error(
+        "Access token must be passed or set via the RECORD_REPLAY_API_KEY environment variable."
+      );
+    }
+
+    return this.sendCommand("Authentication.setAccessToken", {
+      accessToken,
+    });
+  }
+
   async sendCommand(method, params, data) {
     const id = this.nextMessageId++;
-    this.socket.send(JSON.stringify({ id, method, params, binary: data ? true : undefined }));
+    this.socket.send(
+      JSON.stringify({ id, method, params, binary: data ? true : undefined })
+    );
     if (data) {
       this.socket.send(data);
     }

--- a/src/main.js
+++ b/src/main.js
@@ -177,7 +177,7 @@ function maybeLog(verbose, str) {
   }
 }
 
-async function doUploadRecording(dir, server, recording, verbose) {
+async function doUploadRecording(dir, server, recording, verbose, apiKey) {
   maybeLog(verbose, `Starting upload for ${recording.id}...`);
   const reason = uploadSkipReason(recording);
   if (reason) {
@@ -191,7 +191,7 @@ async function doUploadRecording(dir, server, recording, verbose) {
     maybeLog(verbose, `Upload failed: can't read recording from disk: ${e}`);
     return null;
   }
-  if (!await initConnection(server)) {
+  if (!await initConnection(server, apiKey)) {
     maybeLog(verbose, `Upload failed: can't connect to server ${server}`);
     return null;
   }
@@ -213,7 +213,7 @@ async function uploadRecording(id, opts = {}) {
     maybeLog(opts.verbose, `Unknown recording ${id}`);
     return null;
   }
-  return doUploadRecording(dir, server, recording, opts.verbose);
+  return doUploadRecording(dir, server, recording, opts.verbose, opts.apiKey);
 }
 
 async function uploadAllRecordings(opts = {}) {
@@ -223,7 +223,7 @@ async function uploadAllRecordings(opts = {}) {
   let uploadedAll = true;
   for (const recording of recordings) {
     if (!uploadSkipReason(recording)) {
-      if (!await doUploadRecording(dir, server, recording, opts.verbose)) {
+      if (!await doUploadRecording(dir, server, recording, opts.verbose, opts.apiKey)) {
         uploadedAll = false;
       }
     }


### PR DESCRIPTION
Supports either setting `RECORD_REPLAY_API_KEY` environment variable or passing `--api-key` command line argument to configure the API key