### PR TITLE
Fix missing ls output

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,8 @@ function readRecordingFile(dir) {
 }
 
 function writeRecordingFile(dir, lines) {
-  fs.writeFileSync(getRecordingsFile(dir), lines.join("\n"));
+  // Add a trailing newline so the driver can safely append logs
+  fs.writeFileSync(getRecordingsFile(dir), lines.join("\n") + "\n");
 }
 
 function getBuildRuntime(buildId) {


### PR DESCRIPTION
## Issue

The driver appends to the recordings file with a trailing newline. The CLI doesn't add a trailing newline. If you run a CLI operation that updates the recording file and then run a new recording, the recording file becomes corrupted because the driver adds its line on the end of the last line of the file.

## Resolution

Append an extra new line when writing out the file in the CLI. Empty lines are already ignored by the CLI so this has no ill effects.