### PR TITLE
Add install methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/recordings-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "CLI tool for uploading and managing recordings",
   "bin": {
     "replay-recordings": "bin/replay-recordings"

--- a/src/install.js
+++ b/src/install.js
@@ -1,0 +1,99 @@
+// Manage installation of browsers for other NPM packages.
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const https = require("https");
+const path = require("path");
+const { defer, getDirectory } = require("./utils");
+
+async function ensurePlaywrightBrowsersInstalled(kind = "all") {
+  switch (process.platform) {
+    case "darwin":
+      if (["all", "gecko"].includes(kind)) {
+        await installReplayBrowser("macOS-replay-playwright.tar.xz", "firefox", "firefox");
+      }
+      break;
+    case "linux":
+      if (["all", "gecko"].includes(kind)) {
+        await installReplayBrowser("linux-replay-playwright.tar.xz", "firefox", "firefox");
+      }
+      if (["all", "chromium"].includes(kind)) {
+        await installReplayBrowser("linux-replay-chromium.tar.xz", "replay-chromium", "chrome-linux");
+      }
+      break;
+  }
+}
+
+function getPlaywrightBrowserPath(kind) {
+  const replayDir = getDirectory();
+
+  switch (`${process.platform}:${kind}`) {
+    case "darwin:gecko":
+      return path.join(replayDir, "playwright", "firefox", "Nightly.app", "Contents", "MacOS", "firefox");
+    case "linux:gecko":
+      return path.join(replayDir, "playwright", "firefox", "firefox");
+    case "linux:chromium":
+      return path.join(replayDir, "playwright", "chrome-linux", "chrome");
+  }
+  return null;
+}
+
+async function installReplayBrowser(name, srcName, dstName) {
+  const replayDir = getDirectory();
+  const playwrightDir = path.join(replayDir, "playwright");
+
+  if (fs.existsSync(path.join(playwrightDir, dstName))) {
+    return;
+  }
+
+  const contents = await downloadReplayFile(name);
+
+  for (const dir of [replayDir, playwrightDir]) {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
+  }
+  fs.writeFileSync(path.join(playwrightDir, name), contents);
+  spawnSync("tar", ["xf", name], { cwd: playwrightDir });
+  fs.unlinkSync(path.join(playwrightDir, name));
+
+  if (srcName != dstName) {
+    fs.renameSync(path.join(playwrightDir, srcName), path.join(playwrightDir, dstName));
+  }
+}
+
+async function downloadReplayFile(downloadFile) {
+  const options = {
+    host: "static.replay.io",
+    port: 443,
+    path: `/downloads/${downloadFile}`,
+  };
+
+  for (let i = 0; i < 5; i++) {
+    const waiter = defer();
+    const request = https.get(options, response => {
+      if (response.statusCode != 200) {
+        console.log(`Download received status code ${response.statusCode}, retrying...`);
+        request.destroy();
+        waiter.resolve(null);
+        return;
+      }
+      const buffers = [];
+      response.on("data", data => buffers.push(data));
+      response.on("end", () => waiter.resolve(buffers));
+    });
+    request.on("error", err => {
+      console.log(`Download error ${err}, retrying...`);
+      request.destroy();
+      waiter.resolve(null);
+    });
+    const buffers = await waiter.promise;
+    if (buffers) {
+      return Buffer.concat(buffers);
+    }
+  }
+
+  throw new Error("Download failed, giving up");
+}
+
+module.exports = { ensurePlaywrightBrowsersInstalled, getPlaywrightBrowserPath };

--- a/src/main.js
+++ b/src/main.js
@@ -1,13 +1,9 @@
 const fs = require("fs");
 const path = require("path");
 const { initConnection, connectionCreateRecording, connectionUploadRecording, closeConnection } = require("./upload");
-const { maybeLog } = require("./utils");
+const { ensurePlaywrightBrowsersInstalled, getPlaywrightBrowserPath } = require("./install");
+const { getDirectory, maybeLog } = require("./utils");
 const { spawn } = require("child_process");
-
-function getDirectory(opts) {
-  const home = process.env.HOME || process.env.USERPROFILE;
-  return opts.directory || process.env.RECORD_REPLAY_DIRECTORY || path.join(home, ".replay");
-}
 
 function getRecordingsFile(dir) {
   return path.join(dir, "recordings.log");
@@ -336,4 +332,9 @@ module.exports = {
   viewLatestRecording,
   removeRecording,
   removeAllRecordings,
+
+  // These methods aren't documented or available via the CLI, and are used by other
+  // @recordreplay NPM packages.
+  ensurePlaywrightBrowsersInstalled,
+  getPlaywrightBrowserPath,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,6 @@
 
+const path = require("path");
+
 function defer() {
   let resolve, reject;
   const promise = new Promise((res, rej) => {
@@ -14,4 +16,9 @@ function maybeLog(verbose, str) {
   }
 }
 
-module.exports = { defer, maybeLog };
+function getDirectory(opts) {
+  const home = process.env.HOME || process.env.USERPROFILE;
+  return (opts && opts.directory) || process.env.RECORD_REPLAY_DIRECTORY || path.join(home, ".replay");
+}
+
+module.exports = { defer, maybeLog, getDirectory };


### PR DESCRIPTION
Several other packages operate on our playwright browsers, which aren't used just by playwright because they're unbranded and easier for other test runners to deal with.  Instead of copying a bunch of code to each of these packages to manipulate these browsers, it would be better to have them in a common package.  This adds some functionality for this to the recordings-cli package, which isn't accessible via the CLI itself but is exported for use by other node scripts.