### PR TITLE
Automatically process uploaded recordings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/recordings-cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "CLI tool for uploading and managing recordings",
   "bin": {
     "replay-recordings": "bin/replay-recordings"

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,12 @@
 const fs = require("fs");
 const path = require("path");
-const { initConnection, connectionCreateRecording, connectionUploadRecording, closeConnection } = require("./upload");
+const {
+  initConnection,
+  connectionCreateRecording,
+  connectionProcessRecording,
+  connectionUploadRecording,
+  closeConnection,
+} = require("./upload");
 const { ensurePlaywrightBrowsersInstalled, getPlaywrightBrowserPath } = require("./install");
 const { getDirectory, maybeLog } = require("./utils");
 const { spawn } = require("child_process");
@@ -198,6 +204,7 @@ async function doUploadRecording(dir, server, recording, verbose, apiKey) {
   const recordingId = await connectionCreateRecording(recording.buildId);
   maybeLog(verbose, `Created remote recording ${recordingId}, uploading...`);
   addRecordingEvent(dir, "uploadStarted", recording.id, { server, recordingId });
+  connectionProcessRecording(recordingId);
   await connectionUploadRecording(recordingId, contents);
   addRecordingEvent(dir, "uploadFinished", recording.id);
   maybeLog(verbose, "Upload finished.");

--- a/src/upload.js
+++ b/src/upload.js
@@ -43,6 +43,10 @@ async function connectionCreateRecording(buildId) {
   return recordingId;
 }
 
+function connectionProcessRecording(recordingId) {
+  gClient.sendCommand("Recording.processRecording", { recordingId });
+}
+
 // Granularity for splitting up a recording into chunks for uploading.
 const ChunkGranularity = 1024 * 1024;
 


### PR DESCRIPTION
When we create recordings with the replay browser, we start processing them as soon as they've started uploading.  We should do the same for recordings uploaded via the recordings-cli NPM package / CLI tool, so that people viewing these recordings don't have to wait while we do an uncached cold start.