### PR TITLE
Fix export for connectionProcessRecording

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/recordings-cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "CLI tool for uploading and managing recordings",
   "bin": {
     "replay-recordings": "bin/replay-recordings"

--- a/src/upload.js
+++ b/src/upload.js
@@ -83,6 +83,7 @@ function closeConnection() {
 module.exports = {
   initConnection,
   connectionCreateRecording,
+  connectionProcessRecording,
   connectionUploadRecording,
   closeConnection,
 };


### PR DESCRIPTION
Fix a build break from https://github.com/RecordReplay/recordings-cli/pull/10 (the lack of eslint here strikes again).