### PR TITLE
Recognize RECORD_REPLAY_SERVER env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/recordings-cli",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "CLI tool for uploading and managing recordings",
   "bin": {
     "replay-recordings": "bin/replay-recordings"

--- a/src/main.js
+++ b/src/main.js
@@ -169,7 +169,7 @@ function uploadSkipReason(recording) {
 }
 
 function getServer(opts) {
-  return opts.server || "wss://dispatch.replay.io";
+  return opts.server || process.env.RECORD_REPLAY_SERVER || "wss://dispatch.replay.io";
 }
 
 function addRecordingEvent(dir, kind, id, tags = {}) {


### PR DESCRIPTION
Most of our tooling recognizes this env var, and the recordings CLI package should as well.  This simplifies things like cypress integration where we don't want to have a separate option in the cypress configuration that passes this through to the uploadRecording function, when being able to change the server is mainly useful for internal testing.