### PR TITLE
Add command to ensure a recording finishes processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Depending on the status the recording descriptor can have some of the following 
 
 Upload the recording with the given ID to the web service.
 
+### process <id>
+
+Upload a recording, and then process it to ensure it can be replayed successfully.
+
 ### upload-all
 
 Upload all recordings to the web service which can be uploaded.
@@ -95,6 +99,10 @@ Equivalent to `replay-recordings ls`, returns the JSON object for the recordings
 ### uploadRecording(id, opts)
 
 Equivalent to `replay-recordings upload <id>`, returns a promise that resolves with a recording ID if the upload succeeded, or null if uploading failed.
+
+### processRecording(id, opts)
+
+Equivalent to `replay-recordings process <id>`, returns a promise that resolves with a recording ID if the upload and processing succeeded, or null if either failed.
 
 ### uploadAllRecordings(opts)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/recordings-cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "CLI tool for uploading and managing recordings",
   "bin": {
     "replay-recordings": "bin/replay-recordings"

--- a/src/bin.js
+++ b/src/bin.js
@@ -2,6 +2,7 @@ const { program } = require("commander");
 const {
   listAllRecordings,
   uploadRecording,
+  processRecording,
   uploadAllRecordings,
   viewRecording,
   viewLatestRecording,
@@ -35,6 +36,23 @@ program
     "Authentication API Key"
   )
   .action(commandUploadRecording);
+
+program
+  .command("process <id>")
+  .description("Upload a recording to the remote server and process it.")
+  .option(
+    "--directory <dir>",
+    "Alternate recording directory."
+  )
+  .option(
+    "--server <address>",
+    "Alternate server to upload recordings to."
+  )
+  .option(
+    "--api-key <key>",
+    "Authentication API Key"
+  )
+  .action(commandProcessRecording);
 
 program
   .command("upload-all")
@@ -132,6 +150,11 @@ async function commandUploadRecording(id, opts) {
   process.exit(recordingId ? 0 : 1);
 }
 
+async function commandProcessRecording(id, opts) {
+  const recordingId = await processRecording(id, { ...opts, verbose: true });
+  process.exit(recordingId ? 0 : 1);
+}
+
 async function commandUploadAllRecordings(opts) {
   const uploadedAll = await uploadAllRecordings({ ...opts, verbose: true });
   process.exit(uploadedAll ? 0 : 1);
@@ -157,6 +180,7 @@ function commandRemoveAllRecordings(opts) {
   process.exit(0);
 }
 
-function commandUpdateBrowsers(opts) {
-  updateBrowsers({ ...opts, verbose: true }).then(() => process.exit(0));
+async function commandUpdateBrowsers(opts) {
+  await updateBrowsers({ ...opts, verbose: true });
+  process.exit(0);
 }


### PR DESCRIPTION
Fixes https://github.com/RecordReplay/recordings-cli/issues/18.  When a recording is processed successfully the output looks something like:

```
> replay-recordings process 1764793387
Starting upload for 1764793387...
Created remote recording 89cceb7e-f6be-4702-85c3-bd8f128cbff7, uploading...
Setting recording metadata for 89cceb7e-f6be-4702-85c3-bd8f128cbff7
Upload finished.
Processing recording 89cceb7e-f6be-4702-85c3-bd8f128cbff7...
Finished processing.
```

If processing fails, the last line will be something like:

```
Processing failed: session error 99a5c01d-fa24-4cb9-97dc-2f81994b0960/dbb84f8b-d0a7-4fde-acb7-3534c9477ab2: Session died due to an unknown error while replaying
```