### PR TITLE
Add consistent private cross-runner apis for playwright and puppeteer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,50 @@
 {
   "name": "@recordreplay/recordings-cli",
-  "version": "0.4.0",
-  "lockfileVersion": 1,
+  "version": "0.10.1",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@recordreplay/recordings-cli",
+      "version": "0.10.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "commander": "^7.2.0",
+        "ws": "^7.5.0"
+      },
+      "bin": {
+        "replay-recordings": "bin/replay-recordings"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
+      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  },
   "dependencies": {
     "commander": {
       "version": "7.2.0",
@@ -12,7 +54,8 @@
     "ws": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw=="
+      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/recordings-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "CLI tool for uploading and managing recordings",
   "bin": {
     "replay-recordings": "bin/replay-recordings"

--- a/src/main.js
+++ b/src/main.js
@@ -11,8 +11,10 @@ const {
   setRecordingMetadata,
 } = require("./upload");
 const {
+  ensurePuppeteerBrowsersInstalled,
   ensurePlaywrightBrowsersInstalled,
   getPlaywrightBrowserPath,
+  getPuppeteerBrowserPath,
   updateBrowsers,
 } = require("./install");
 const { getDirectory, maybeLog } = require("./utils");
@@ -503,5 +505,7 @@ module.exports = {
   // These methods aren't documented or available via the CLI, and are used by other
   // @recordreplay NPM packages.
   ensurePlaywrightBrowsersInstalled,
+  ensurePuppeteerBrowsersInstalled,
   getPlaywrightBrowserPath,
+  getPuppeteerBrowserPath,
 };


### PR DESCRIPTION
Adds a couple internal methods to install both playwright and puppeteer browsers and return the executable path for each. Will be used by `puppeteer-config` and `playwright` config to determine the path to each respective browser and to install the browsers.