### PR TITLE
Fix upload-all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@recordreplay/recordings-cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@recordreplay/recordings-cli",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/recordings-cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "CLI tool for uploading and managing recordings",
   "bin": {
     "replay-recordings": "bin/replay-recordings"

--- a/src/upload.js
+++ b/src/upload.js
@@ -6,24 +6,25 @@ let gClientReady = defer();
 
 async function initConnection(server, accessToken, verbose, agent) {
   if (!gClient) {
+    let { resolve } = gClientReady;
     gClient = new ProtocolClient(
       server,
       {
         async onOpen() {
           try {
             await gClient.setAccessToken(accessToken);
-            gClientReady.resolve(true);
+            resolve(true);
           } catch (err) {
             maybeLog(verbose, `Error authenticating with server: ${err}`);
-            gClientReady.resolve(false);
+            resolve(false);
           }
         },
         onClose() {
-          gClientReady.resolve(false);
+          resolve(false);
         },
         onError(e) {
           maybeLog(verbose, `Error connecting to server: ${e}`);
-          gClientReady.resolve(false);
+          resolve(false);
         },
       },
       {
@@ -121,6 +122,7 @@ function closeConnection() {
   if (gClient) {
     gClient.close();
     gClient = undefined;
+    gClientReady = defer();
   }
 }
 


### PR DESCRIPTION
## Issue

When uploading all recordings, the first recording works but subsequent fail with an error

## Analysis

`gClient` was uninitialized when the socket was closed but the `gClientReady` promise wasn't so the client tries to send a command before the socket is ready.

## Resolution

* Reinitialize `gClientReady` when `gClient` is cleared
* Deconstruct `resolve` from `gClientReady` because referencing the global caused it to be resolved incorrectly by the `close` event handler from the prior upload